### PR TITLE
MacOS fix and fix for trailing space

### DIFF
--- a/src/s3repo/command.py
+++ b/src/s3repo/command.py
@@ -11,7 +11,7 @@ def Main(args=sys.argv[1:]):
   try:
     DEFAULT_CODENAME = subprocess.check_output(["lsb_release", "--codename",
       "--short"]).decode("utf-8").strip()
-  except subprocess.CalledProcessError:
+  except (subprocess.CalledProcessError, FileNotFoundError):
     DEFAULT_CODENAME = None
 
   parser = argparse.ArgumentParser(

--- a/src/s3repo/field_set.py
+++ b/src/s3repo/field_set.py
@@ -15,7 +15,7 @@ class FieldSet(object):
         self.fields.append((key, value))
       else:
         key, value = line.split(":", 1)
-        self.fields.append((key, value.lstrip()))
+        self.fields.append((key, value.lstrip().rstrip()))
 
   def __str__(self):
     rv = ""


### PR DESCRIPTION
- add exception which happens on MacOS b/c "lsb_release" doesn't exist
- handle trailing space in package name from "dpkg-deb" output for
  "NessusAgent" package
